### PR TITLE
Issue27 create duplicate group

### DIFF
--- a/src/main/java/manitto/backend/domain/group/dto/request/GroupCreateReq.java
+++ b/src/main/java/manitto/backend/domain/group/dto/request/GroupCreateReq.java
@@ -1,6 +1,6 @@
 package manitto.backend.domain.group.dto.request;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,9 +8,9 @@ import lombok.Setter;
 @Setter
 public class GroupCreateReq {
 
-    @NotNull
+    @NotBlank
     private String groupName;
 
-    @NotNull
+    @NotBlank
     private String leaderName;
 }

--- a/src/main/java/manitto/backend/domain/group/repository/GroupRepository.java
+++ b/src/main/java/manitto/backend/domain/group/repository/GroupRepository.java
@@ -4,4 +4,6 @@ import manitto.backend.domain.group.entity.Group;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface GroupRepository extends MongoRepository<Group, String> {
+
+    boolean existsByLeaderNameAndGroupName(String leaderName, String groupName);
 }

--- a/src/main/java/manitto/backend/domain/group/service/GroupService.java
+++ b/src/main/java/manitto/backend/domain/group/service/GroupService.java
@@ -13,9 +13,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class GroupService {
 
+    private final GroupValidator groupValidator;
     private final GlobalMongoTemplateRepository globalMongoTemplateRepository;
 
     public GroupCreateRes create(GroupCreateReq req) {
+
+        groupValidator.validateLeaderAndGroupUnique(req.getLeaderName(), req.getGroupName());
 
         Group group = Group.create(req.getLeaderName(), req.getGroupName(), PasswordProvider.generatePassword());
         group = globalMongoTemplateRepository.saveWithoutDuplicatedId(group, Group.class);

--- a/src/main/java/manitto/backend/domain/group/service/GroupService.java
+++ b/src/main/java/manitto/backend/domain/group/service/GroupService.java
@@ -17,11 +17,7 @@ public class GroupService {
 
     public GroupCreateRes create(GroupCreateReq req) {
 
-        String leaderName = req.getLeaderName();
-        String groupName = req.getGroupName();
-        String password = PasswordProvider.generatePassword();
-
-        Group group = Group.create(leaderName, groupName, password);
+        Group group = Group.create(req.getLeaderName(), req.getGroupName(), PasswordProvider.generatePassword());
         group = globalMongoTemplateRepository.saveWithoutDuplicatedId(group, Group.class);
 
         return GroupDtoMapper.toGroupCreateRes(group.getId());

--- a/src/main/java/manitto/backend/domain/group/service/GroupValidator.java
+++ b/src/main/java/manitto/backend/domain/group/service/GroupValidator.java
@@ -17,4 +17,10 @@ public class GroupValidator {
             throw new CustomException(ErrorCode.GROUP_NOT_FOUND);
         }
     }
+
+    public void validateLeaderAndGroupUnique(String leaderName, String groupName) {
+        if (groupRepository.existsByLeaderNameAndGroupName(leaderName, groupName)) {
+            throw new CustomException(ErrorCode.GROUP_LEADER_AND_GROUP_NAME_DUPLICATED);
+        }
+    }
 }

--- a/src/main/java/manitto/backend/global/exception/ErrorCode.java
+++ b/src/main/java/manitto/backend/global/exception/ErrorCode.java
@@ -40,7 +40,7 @@ public enum ErrorCode {
     // Group
     GROUP_NOT_FOUND(-400, "조회된 그룹이 없습니다.", 406),
     GROUP_INTEGRITY_VIOLATION(-402, "유효하지 않은 그룹 정보가 검출되었습니다.", 500),
-    ;
+    GROUP_LEADER_AND_GROUP_NAME_DUPLICATED(-403, "이미 동일한 리더 이름, 그룹 이름을 사용하는 그룹이 존재합니다.", 400);
 
     private final int errorCode;
     private final String message;

--- a/src/main/java/manitto/backend/global/exception/ErrorCode.java
+++ b/src/main/java/manitto/backend/global/exception/ErrorCode.java
@@ -39,7 +39,7 @@ public enum ErrorCode {
 
     // Group
     GROUP_NOT_FOUND(-400, "조회된 그룹이 없습니다.", 406),
-    GROUP_INTEGRITY_VIOLATION(-402, "유효하지 않은 그룹 정보가 검출되었습니다.", 406),
+    GROUP_INTEGRITY_VIOLATION(-402, "유효하지 않은 그룹 정보가 검출되었습니다.", 500),
     ;
 
     private final int errorCode;

--- a/src/test/java/manitto/backend/domain/group/service/GroupValidatorTest.java
+++ b/src/test/java/manitto/backend/domain/group/service/GroupValidatorTest.java
@@ -58,4 +58,38 @@ class GroupValidatorTest {
                 .extracting(e -> ((CustomException) e).getErrorCode())
                 .isEqualTo(ErrorCode.GROUP_NOT_FOUND);
     }
+
+    @Test
+    void validateLeaderAndGroupUnique_정상_입력한_리더_이름과_그룹_이름이_유일함() {
+        // given
+        String leaderName = "새로운리더";
+        String groupName = "새로운그룹";
+
+        when(groupRepository.existsByLeaderNameAndGroupName(leaderName, groupName))
+                .thenReturn(false);
+
+        // when
+
+        // then
+        assertThatCode(() -> groupValidator.validateLeaderAndGroupUnique(leaderName, groupName))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void validateLeaderAndGroupUnique_에러_입력한_리더_이름과_그룹_이름이_유일하지_않음() {
+        // given
+        String leaderName = "이미존재하는리더";
+        String groupName = "이미존재하는그룹";
+
+        when(groupRepository.existsByLeaderNameAndGroupName(leaderName, groupName))
+                .thenReturn(true);
+
+        // when
+
+        // then
+        assertThatThrownBy(() -> groupValidator.validateLeaderAndGroupUnique(leaderName, groupName))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.GROUP_LEADER_AND_GROUP_NAME_DUPLICATED);
+    }
 }


### PR DESCRIPTION
### PR Description
- 누락되었던 그룹 생성 입력 값에 대한 검증을 추가하였습니다.
- 이미 존재하는 그룹과 리더 이름, 그룹 이름이 모두 동일한 그룹을 생성할 수 없습니다.
- 즉, 특정 리더 이름 + 그룹 이름 조합을 가진 그룹은 유일해야 합니다.