### PR TITLE
🐛 Fix: Null 체크 로직 추가 및 검증 보완

### DIFF
--- a/src/main/java/manitto/backend/domain/match/service/MatchService.java
+++ b/src/main/java/manitto/backend/domain/match/service/MatchService.java
@@ -3,7 +3,6 @@ package manitto.backend.domain.match.service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import manitto.backend.domain.group.entity.Group;
-import manitto.backend.domain.group.repository.GroupRepository;
 import manitto.backend.domain.group.repository.GroupTemplateRepository;
 import manitto.backend.domain.group.service.GroupValidator;
 import manitto.backend.domain.match.dto.mapper.MatchDtoMapper;
@@ -30,7 +29,6 @@ public class MatchService {
     private final MatchValidator matchValidator;
     private final GroupValidator groupValidator;
     private final MatchProcessor matchProcessor;
-    private final GroupRepository groupRepository;
 
     public MatchGetResultRes getUserResult(String groupId, String name, MatchGetResultReq req) {
         Match match = matchTemplateRepository.findMatchResultByGroupIdAndGiverAndPassword(
@@ -47,7 +45,7 @@ public class MatchService {
 
         List<MatchResult> matchResults = matchProcessor.matching(req.getNames());
         Match match = Match.create(groupId, matchResults);
-        match = globalMongoTemplateRepository.saveWithoutDuplicatedId(match, Match.class);
+        globalMongoTemplateRepository.saveWithoutDuplicatedId(match, Match.class);
 
         return MatchDtoMapper.toMatchAllResultRes(groupId, matchResults);
     }

--- a/src/main/java/manitto/backend/domain/match/service/MatchService.java
+++ b/src/main/java/manitto/backend/domain/match/service/MatchService.java
@@ -16,6 +16,7 @@ import manitto.backend.domain.match.entity.Match;
 import manitto.backend.domain.match.entity.MatchResult;
 import manitto.backend.domain.match.repository.MatchTemplateRepository;
 import manitto.backend.global.repository.GlobalMongoTemplateRepository;
+import manitto.backend.global.util.StringListProcessor;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -41,9 +42,12 @@ public class MatchService {
     public MatchAllResultRes matchStart(String groupId, MatchStartReq req) {
         groupValidator.validateExists(groupId);
         matchValidator.validateAlreadyExists(groupId);
-        matchValidator.validateDuplicateName(req.getNames());
 
-        List<MatchResult> matchResults = matchProcessor.matching(req.getNames());
+        List<String> names = StringListProcessor.filterNotBlank(req.getNames());
+        matchValidator.validateMinimumSize(names);
+        matchValidator.validateDuplicateName(names);
+
+        List<MatchResult> matchResults = matchProcessor.matching(names);
         Match match = Match.create(groupId, matchResults);
         globalMongoTemplateRepository.saveWithoutDuplicatedId(match, Match.class);
 

--- a/src/main/java/manitto/backend/domain/match/service/MatchValidator.java
+++ b/src/main/java/manitto/backend/domain/match/service/MatchValidator.java
@@ -32,7 +32,7 @@ public class MatchValidator {
     }
 
     public void validateMinimumSize(List<String> names) {
-        if (names == null || names.size() < 2) {
+        if (names.size() < 2) {
             throw new CustomException(ErrorCode.MATCH_MEMBER_SIZE_TOO_SMALL);
         }
     }

--- a/src/main/java/manitto/backend/domain/match/service/MatchValidator.java
+++ b/src/main/java/manitto/backend/domain/match/service/MatchValidator.java
@@ -31,4 +31,9 @@ public class MatchValidator {
         }
     }
 
+    public void validateMinimumSize(List<String> names) {
+        if (names == null || names.size() < 2) {
+            throw new CustomException(ErrorCode.MATCH_MEMBER_SIZE_TOO_SMALL);
+        }
+    }
 }

--- a/src/main/java/manitto/backend/domain/match/service/MatchValidator.java
+++ b/src/main/java/manitto/backend/domain/match/service/MatchValidator.java
@@ -1,8 +1,8 @@
 package manitto.backend.domain.match.service;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import manitto.backend.domain.match.repository.MatchRepository;
 import manitto.backend.global.exception.CustomException;
@@ -22,7 +22,10 @@ public class MatchValidator {
     }
 
     public void validateDuplicateName(List<String> names) {
-        Set<String> uniqueNames = new HashSet<>(names);
+        Set<String> uniqueNames = names.stream()
+                .map(String::trim)
+                .collect(Collectors.toSet());
+
         if (names.size() != uniqueNames.size()) {
             throw new CustomException(ErrorCode.MATCH_MEMBER_NAME_DUPLICATED);
         }

--- a/src/main/java/manitto/backend/global/exception/ErrorCode.java
+++ b/src/main/java/manitto/backend/global/exception/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
     MATCH_INTEGRITY_VIOLATION(-302, "유효하지 않은 매치 정보가 검출되었습니다.", 500),
     MATCH_MEMBER_NAME_DUPLICATED(-303, "멤버 이름은 중복되면 안됩니다.", 400),
     MATCH_ALREADY_EXIST(-304, "이미 매칭된 그룹입니다.", 409),
+    MATCH_MEMBER_SIZE_TOO_SMALL(-305, "매칭을 위해서는 최소 2명 이상이 필요합니다.", 422),
 
     // Group
     GROUP_NOT_FOUND(-400, "조회된 그룹이 없습니다.", 406),

--- a/src/main/java/manitto/backend/global/exception/ExceptionAdvice.java
+++ b/src/main/java/manitto/backend/global/exception/ExceptionAdvice.java
@@ -37,7 +37,8 @@ public class ExceptionAdvice {
     protected ErrorResponse<ServerErrorData> handleUntrackedException(Exception e) {
         log.error("[UNTRACKED ERROR] class: [{}], message: [{}]",
                 e.getClass().getSimpleName(),
-                e.getMessage());
+                e.getMessage(),
+                e);
 
         ServerErrorData serverErrorData = ServerErrorData.builder()
                 .errorClass(e.getClass().toString())
@@ -109,7 +110,8 @@ public class ExceptionAdvice {
             log.error("[ORIGIN ERROR] class: [{}], message: [{}], localizedMessage: [{}]",
                     e.getOriginException().getClass().getSimpleName(),
                     e.getOriginException().getMessage(),
-                    e.getOriginException().getLocalizedMessage());
+                    e.getOriginException().getLocalizedMessage(),
+                    e.getOriginException());
         }
         log.info("[CUSTOM EXCEPTION] class: [{}], message: [{}]",
                 e.getClass().getSimpleName(),

--- a/src/main/java/manitto/backend/global/util/StringListProcessor.java
+++ b/src/main/java/manitto/backend/global/util/StringListProcessor.java
@@ -1,0 +1,18 @@
+package manitto.backend.global.util;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class StringListProcessor {
+
+    private StringListProcessor() {
+    }
+
+    public static List<String> filterNotBlank(List<String> list) {
+
+        return list.stream()
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/manitto/backend/global/util/StringListProcessor.java
+++ b/src/main/java/manitto/backend/global/util/StringListProcessor.java
@@ -2,14 +2,12 @@ package manitto.backend.global.util;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.experimental.UtilityClass;
 
+@UtilityClass
 public class StringListProcessor {
 
-    private StringListProcessor() {
-    }
-
     public static List<String> filterNotBlank(List<String> list) {
-
         return list.stream()
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())

--- a/src/test/java/manitto/backend/domain/match/service/MatchServiceTest.java
+++ b/src/test/java/manitto/backend/domain/match/service/MatchServiceTest.java
@@ -103,6 +103,49 @@ class MatchServiceTest {
     }
 
     @Test
+    void matchStart_에러_빈_문자열_포함_멤버가_2명() {
+        // given
+        String leaderName = "leader";
+        String groupName = "group";
+        String password = "password";
+
+        String member1 = "name1";
+        String member2 = "";
+        MatchStartReq req = MatchDtoMother.createMatchStartReq(List.of(member1, member2));
+
+        Group group = Group.create(leaderName, groupName, password);
+        group = groupRepository.save(group);
+        String groupId = group.getId();
+
+        // when & then
+        assertThatThrownBy(() -> matchService.matchStart(groupId, req))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MATCH_MEMBER_SIZE_TOO_SMALL);
+    }
+
+    @Test
+    void matchStart_에러_응답_멤버가_1명() {
+        // given
+        String leaderName = "leader";
+        String groupName = "group";
+        String password = "password";
+
+        String member1 = "name1";
+        MatchStartReq req = MatchDtoMother.createMatchStartReq(List.of(member1));
+
+        Group group = Group.create(leaderName, groupName, password);
+        group = groupRepository.save(group);
+        String groupId = group.getId();
+
+        // when & then
+        assertThatThrownBy(() -> matchService.matchStart(groupId, req))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MATCH_MEMBER_SIZE_TOO_SMALL);
+    }
+
+    @Test
     void getGroupResult_정상_응답() {
         // given
         String leaderName = "리더명";

--- a/src/test/java/manitto/backend/domain/match/service/MatchServiceTest.java
+++ b/src/test/java/manitto/backend/domain/match/service/MatchServiceTest.java
@@ -117,7 +117,9 @@ class MatchServiceTest {
         group = groupRepository.save(group);
         String groupId = group.getId();
 
-        // when & then
+        // when
+
+        // then
         assertThatThrownBy(() -> matchService.matchStart(groupId, req))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
@@ -138,7 +140,9 @@ class MatchServiceTest {
         group = groupRepository.save(group);
         String groupId = group.getId();
 
-        // when & then
+        // when
+
+        // then
         assertThatThrownBy(() -> matchService.matchStart(groupId, req))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")

--- a/src/test/java/manitto/backend/domain/match/service/MatchServiceTest.java
+++ b/src/test/java/manitto/backend/domain/match/service/MatchServiceTest.java
@@ -75,8 +75,8 @@ class MatchServiceTest {
     @Test
     void matchStart_정상_응답_멤버가_2명() {
         // given
-        String leaderName = "leader";
-        String groupName = "group";
+        String leaderName = "leader\n";
+        String groupName = "\bgroup";
         String password = "password";
 
         String member1 = "name1";
@@ -90,6 +90,9 @@ class MatchServiceTest {
         MatchAllResultRes result = matchService.matchStart(group.getId(), req);
 
         // then
+        assertThat(group.getLeaderName()).isEqualTo("leader");
+        assertThat(group.getGroupName()).isEqualTo("group");
+
         assertThat(result).isNotNull();
         assertThat(result.getGroupId()).isEqualTo(group.getId());
         assertThat(result.getResult())

--- a/src/test/java/manitto/backend/domain/match/service/MatchValidatorTest.java
+++ b/src/test/java/manitto/backend/domain/match/service/MatchValidatorTest.java
@@ -84,4 +84,18 @@ class MatchValidatorTest {
                 .extracting(e -> ((CustomException) e).getErrorCode())
                 .isEqualTo(ErrorCode.MATCH_MEMBER_NAME_DUPLICATED);
     }
+
+    @Test
+    void validateDuplicateName_에러_trim_수행을_통해_중복된_이름을_검출() {
+        // given
+        List<String> names = List.of("중복된이름", "중복된이름 ", "이름3");
+
+        // when
+
+        // then
+        assertThatThrownBy(() -> matchValidator.validateDuplicateName(names))
+                .isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.MATCH_MEMBER_NAME_DUPLICATED);
+    }
 }


### PR DESCRIPTION
### PR Description
- `MatchService` 내 불필요한 변수 및 필드 제거
- 비즈니스 예외, 추적되지 않는 예외에 대한 **StackTrace 추가**
- **매칭 리스트 요소 정제**: trim 처리 후 빈 문자열 제거
- **매칭 시작 전 멤버 인원 수 검증** 수행
  - 총 2인 이상일 때 매칭 시작 가능
  - 멤버 수 부족 시 `MATCH_MEMBER_SIZE_TOO_SMALL` 예외 발생
- 관련 테스트 추가

### Related Issue

- #45 