### PR TITLE
✨ Feat: 그룹 생성 시 누적 그룹 카운트 업데이트 비동기 처리 및 재시도 로직 추가

### DIFF
--- a/src/main/java/manitto/backend/domain/group/service/GroupCountIncrementer.java
+++ b/src/main/java/manitto/backend/domain/group/service/GroupCountIncrementer.java
@@ -22,6 +22,9 @@ public class GroupCountIncrementer {
         long delay = INITIAL_DELAY_MS;
         for (int attempt = 0; attempt < MAX_RETRY; attempt++) {
             try {
+                if (attempt == 1) {
+                    log.info("[GROUP COUNT UPDATE FAILED] 재시도 수행");
+                }
                 groupCountTemplateRepository.updateTotalGroups();
                 return;
             } catch (Exception e) {
@@ -30,7 +33,9 @@ public class GroupCountIncrementer {
                     return;
                 }
             }
-            if (!sleep(delay)) return;
+            if (!sleep(delay)) {
+                return;
+            }
             delay *= 2;
         }
     }

--- a/src/main/java/manitto/backend/domain/group/service/GroupCountIncrementer.java
+++ b/src/main/java/manitto/backend/domain/group/service/GroupCountIncrementer.java
@@ -1,0 +1,47 @@
+package manitto.backend.domain.group.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import manitto.backend.domain.group.repository.GroupCountTemplateRepository;
+import manitto.backend.global.config.app.AsyncConfig;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GroupCountIncrementer {
+
+    private static final int MAX_RETRY = 3;
+    private static final long INITIAL_DELAY_MS = 100;
+
+    private final GroupCountTemplateRepository groupCountTemplateRepository;
+
+    @Async(AsyncConfig.COUNT_UPDATE_EXECUTOR)
+    public void increment() {
+        long delay = INITIAL_DELAY_MS;
+        for (int attempt = 0; attempt < MAX_RETRY; attempt++) {
+            try {
+                groupCountTemplateRepository.updateTotalGroups();
+                return;
+            } catch (Exception e) {
+                if (attempt == MAX_RETRY - 1) {
+                    log.warn("[GROUP COUNT UPDATE FAILED] 재시도 소진 (시도 횟수: [{}]), 오류: [{}]", MAX_RETRY, e.getMessage());
+                    return;
+                }
+            }
+            if (!sleep(delay)) return;
+            delay *= 2;
+        }
+    }
+
+    private boolean sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+}

--- a/src/main/java/manitto/backend/domain/group/service/GroupService.java
+++ b/src/main/java/manitto/backend/domain/group/service/GroupService.java
@@ -21,6 +21,7 @@ public class GroupService {
 
     private final GroupValidator groupValidator;
     private final GroupRepository groupRepository;
+    private final GroupCountIncrementer groupCountIncrementer;
     private final GroupCountTemplateRepository groupCountTemplateRepository;
     private final GlobalMongoTemplateRepository globalMongoTemplateRepository;
 
@@ -29,7 +30,7 @@ public class GroupService {
 
         Group group = Group.create(req.getLeaderName(), req.getGroupName(), PasswordProvider.generatePassword());
         globalMongoTemplateRepository.saveWithoutDuplicatedId(group, Group.class);
-        groupCountTemplateRepository.updateTotalGroups();
+        groupCountIncrementer.increment();
 
         return GroupDtoMapper.toGroupCreateRes(group.getId(), group.getLeaderName(), group.getGroupName(),
                 group.getPassword());

--- a/src/main/java/manitto/backend/global/config/app/AsyncConfig.java
+++ b/src/main/java/manitto/backend/global/config/app/AsyncConfig.java
@@ -1,0 +1,25 @@
+package manitto.backend.global.config.app;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    public static final String COUNT_UPDATE_EXECUTOR = "countUpdateExecutor";
+
+    @Bean(name = COUNT_UPDATE_EXECUTOR)
+    public Executor countUpdateExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(3);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("count-update-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/manitto/backend/global/config/app/AsyncConfig.java
+++ b/src/main/java/manitto/backend/global/config/app/AsyncConfig.java
@@ -1,6 +1,7 @@
 package manitto.backend.global.config.app;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -19,6 +20,9 @@ public class AsyncConfig {
         executor.setMaxPoolSize(3);
         executor.setQueueCapacity(100);
         executor.setThreadNamePrefix("count-update-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(20);
         executor.initialize();
         return executor;
     }

--- a/src/test/java/manitto/backend/domain/group/service/GroupServiceTest.java
+++ b/src/test/java/manitto/backend/domain/group/service/GroupServiceTest.java
@@ -1,8 +1,10 @@
 package manitto.backend.domain.group.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import manitto.backend.config.mongo.EnableMongoTestServer;
 import manitto.backend.domain.group.dto.request.GroupCreateReq;
 import manitto.backend.domain.group.dto.response.GroupCountRes;
@@ -55,7 +57,7 @@ public class GroupServiceTest {
     }
 
     @Test
-    void create_정상_그룹을_생성하면_groupCount가_1_증가한다() {
+    void create_정상_그룹을_생성하면_groupCount가_비동기로_1_증가한다() {
         //given
         String groupName = "포켓몬";
         String leaderName = "팽도리";
@@ -70,7 +72,9 @@ public class GroupServiceTest {
         assertThat(result).isNotNull();
         assertThat(result.getGroupId()).isNotBlank();
 
-        assertThat(groupCountTemplateRepository.getTotalGroups()).isEqualTo(beforeCreate + 1);
+        await().atMost(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(groupCountTemplateRepository.getTotalGroups())
+                        .isEqualTo(beforeCreate + 1));
     }
 
     @Test

--- a/src/test/java/manitto/backend/domain/group/service/GroupServiceTest.java
+++ b/src/test/java/manitto/backend/domain/group/service/GroupServiceTest.java
@@ -1,6 +1,7 @@
 package manitto.backend.domain.group.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 import java.util.Optional;
@@ -12,6 +13,7 @@ import manitto.backend.domain.group.dto.response.GroupCreateRes;
 import manitto.backend.domain.group.entity.Group;
 import manitto.backend.domain.group.repository.GroupCountTemplateRepository;
 import manitto.backend.domain.group.repository.GroupRepository;
+import manitto.backend.global.exception.CustomException;
 import manitto.backend.testUtil.GroupDtoMother;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -75,6 +77,28 @@ public class GroupServiceTest {
         await().atMost(1, TimeUnit.SECONDS)
                 .untilAsserted(() -> assertThat(groupCountTemplateRepository.getTotalGroups())
                         .isEqualTo(beforeCreate + 1));
+    }
+
+    @Test
+    void create_실패_그룹_생성이_실패하면_groupCount가_증가하지_않는다() throws InterruptedException {
+        // given: 첫 번째 그룹 생성 성공 및 비동기 카운트 증가 대기
+        GroupCreateReq req = GroupDtoMother.createGroupCreateReq("포켓몬", "팽도리");
+        int countBefore = groupCountTemplateRepository.getTotalGroups();
+
+        groupService.create(req);
+        await().atMost(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(groupCountTemplateRepository.getTotalGroups())
+                        .isEqualTo(countBefore + 1));
+
+        int countBeforeFailure = groupCountTemplateRepository.getTotalGroups();
+
+        // when: 동일한 리더 이름 + 그룹 이름으로 중복 생성 시도 → 예외 발생
+        assertThatThrownBy(() -> groupService.create(req))
+                .isInstanceOf(CustomException.class);
+
+        // then: 비동기 작업이 실행될 여지(500ms)를 줘도 카운트가 변하지 않아야 함
+        Thread.sleep(500);
+        assertThat(groupCountTemplateRepository.getTotalGroups()).isEqualTo(countBeforeFailure);
     }
 
     @Test


### PR DESCRIPTION
### PR Description

#### 배경

그룹 생성(`Group` 저장)과 카운트 업데이트(`GroupCount` 증가)는 의도적으로 별개의 작업으로 설계되어 있습니다.
카운트 업데이트 실패 시 그룹 생성이 롤백되어서는 안 되기 때문에 트랜잭션으로 묶지 않았고, 이 설계는 유지합니다.

#### 문제

기존 구현은 카운트 업데이트 실패 시 재시도 로직이 없어 카운트 누락이 조용히 발생할 수 있었습니다.
재시도 로직을 동기로 추가할 경우, 지수 백오프 대기 시간이 응답 속도에 직접적인 영향을 줍니다.

#### 해결

카운트 업데이트를 비동기로 전환하여 응답 반환 시점과 분리하고, 백그라운드에서 최대 3회 지수 백오프 재시도를 수행합니다.
재시도 소진 시 WARN 로그를 남깁니다.

#### 트레이드오프

- 카운트가 실제로 반영되는 시점이 응답보다 약간 늦어질 수 있습니다. 카운트는 누적 표시 용도로만 사용되므로 허용 가능한 범위입니다.
- 재시도를 모두 소진하면 카운트 불일치가 남을 수 있으나, 이는 기존 구현에서도 동일하게 존재하던 문제입니다. 비동기 전환으로 새롭게 발생하는 리스크가 아닙니다.

#### 변경 사항

- `AsyncConfig`: `@EnableAsync` 및 전용 스레드풀(`countUpdateExecutor`, core 2 / max 3) 설정 추가
- `GroupCountIncrementer`: `@Async` 기반 비동기 실행 + 지수 백오프 재시도 + WARN 로그
- `GroupService`: 동기 카운트 호출 → `GroupCountIncrementer.increment()` 호출로 변경
- `GroupServiceTest`: 비동기 카운트 증가 검증을 위해 Awaitility 적용

### Related Issue

- #50 